### PR TITLE
chore: Refactor socket monitoring and memory metrics calculation

### DIFF
--- a/src/services/prometheus.js
+++ b/src/services/prometheus.js
@@ -56,11 +56,11 @@ const getCpuMetrics = async (address) => {
 
 const getMemoryMetrics = async (address) => {
   const totalMemoryQuery = `node_memory_total_bytes`;
-  const memoryUsedQuery = `node_memory_total_bytes - node_memory_free_bytes`;
+  const memoryUsedQuery = `(node_memory_total_bytes - node_memory_free_bytes) / node_memory_total_bytes * 100`;
   const swapUsedQuery = `node_memory_swap_used_bytes`;
   const memoryFreeQuery = `node_memory_free_bytes`;
 
-  const memoryUsed = convertBytes(
+  const memoryUsed = Math.round(
     await queryPrometheus(memoryUsedQuery, address),
   );
   const memoryFree = convertBytes(

--- a/src/sockets/monitor.js
+++ b/src/sockets/monitor.js
@@ -66,7 +66,7 @@ const setupMonitoringSocket = (io) => {
       }
     };
 
-    const intervalId = setInterval(sendData, 3000);
+    const intervalId = setInterval(sendData, 5000);
 
     socket.on("disconnect", () => {
       console.log(`Client disconnected: ${socket.id}`);


### PR DESCRIPTION
## What is this PR?

In this commit, we've made significant improvements to the backend's socket monitoring functionality and the way memory metrics are calculated. Specifically, the getMemoryMetrics function within the feature/socket/monitor/node branch has been refactored. The key change here is the shift from representing memory usage in bytes to a percentage format. This alteration aims to provide a clearer and more intuitive understanding of memory utilization for users on the frontend interface.

Additionally, we've addressed an issue regarding the frequency of data updates sent to the frontend. Previously, updates were sent every 3 seconds, which caused intermittent disruptions in the frontend's display. To resolve this, the interval for intervalId in the setupMonitoringSocket function has been extended to 5 seconds. This change effectively smooths out the data transmission, enhancing the overall stability and performance of the frontend visualization.

<br>