### PR TITLE
feat: Add API to Provide Access Request Data for User's Server Addresses

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const path = require("path");
 const cookieParser = require("cookie-parser");
 const logger = require("morgan");
 const usersRouter = require("./src/routes/users");
+const adminUsersRouter = require("./src/routes/adminUsers");
 const connectDatabase = require("./src/config/database");
 const corsMiddleware = require("./src/middlewares/cors");
 const setupMonitoringSocket = require("./src/sockets/monitor");
@@ -30,6 +31,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, "public")));
 app.use("/api/v1/users", usersRouter);
+app.use("/api/v1/admin", adminUsersRouter);
 app.use((req, res) => {
   res.status(404).send("Not Found");
 });

--- a/src/controllers/adminUser.js
+++ b/src/controllers/adminUser.js
@@ -1,0 +1,32 @@
+const ServerAddress = require("../models/ServerAddress");
+const UserServerRelation = require("../models/UserServerRelation");
+
+const getPendingRequests = async (req, res) => {
+  const addressId = req.params.addressId;
+
+  try {
+    const requests = await UserServerRelation.find({
+      addressId,
+      isAdmin: false,
+    }).lean();
+
+    const addressInfo = await ServerAddress.findById(addressId);
+
+    res.status(200).json({
+      isAdmin: true,
+      requests: requests,
+      address: addressInfo.address,
+    });
+  } catch (error) {
+    console.error(error);
+
+    res.status(500).json({
+      status: "Error",
+      message: "Server encountered an error processing the request.",
+    });
+  }
+};
+
+module.exports = {
+  getPendingRequests,
+};

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -4,8 +4,9 @@ const UserServerRelation = require("../models/UserServerRelation");
 const User = require("../models/User");
 
 const getUserInformation = async (req, res) => {
+  const uid = req.params.uid;
+
   try {
-    const uid = req.params.uid;
     const userInfo = await User.findOne({ uid });
 
     if (!userInfo) {
@@ -27,15 +28,15 @@ const getUserInformation = async (req, res) => {
 };
 
 const getUserServerAddresses = async (req, res) => {
+  const userId = req.params.userId;
+
+  if (!mongoose.Types.ObjectId.isValid(userId)) {
+    return res
+      .status(400)
+      .json({ status: "Error", message: "Invalid user ID." });
+  }
+
   try {
-    const userId = req.params.userId;
-
-    if (!mongoose.Types.ObjectId.isValid(userId)) {
-      return res
-        .status(400)
-        .json({ status: "Error", message: "Invalid user ID." });
-    }
-
     const relation = await UserServerRelation.find({ userId })
       .populate("addressId")
       .exec();
@@ -61,16 +62,16 @@ const getUserServerAddresses = async (req, res) => {
 };
 
 const registerServerAddress = async (req, res) => {
+  const userId = req.params.userId;
+  const { serverAddress } = req.body;
+
+  if (!mongoose.Types.ObjectId.isValid(userId)) {
+    return res
+      .status(400)
+      .json({ status: "Error", message: "Invalid user ID." });
+  }
+
   try {
-    const userId = req.params.userId;
-    const { serverAddress } = req.body;
-
-    if (!mongoose.Types.ObjectId.isValid(userId)) {
-      return res
-        .status(400)
-        .json({ status: "Error", message: "Invalid user ID." });
-    }
-
     let address = await ServerAddress.findOne({ address: serverAddress });
     let isNewAddress = false;
 
@@ -109,7 +110,7 @@ const registerServerAddress = async (req, res) => {
     await relation.save();
 
     res.status(200).json({
-      status: "success",
+      status: "Success",
       message: "Server address added successfully.",
     });
   } catch (error) {

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -2,12 +2,12 @@ const admin = require("firebase-admin");
 const User = require("../models/User");
 
 module.exports.verifyToken = async (req, res, next) => {
+  const token =
+    req.headers.authorization && req.headers.authorization.startsWith("Bearer ")
+      ? req.headers.authorization.split(" ")[1]
+      : req.body.token;
+
   try {
-    const token =
-      req.headers.authorization &&
-      req.headers.authorization.startsWith("Bearer ")
-        ? req.headers.authorization.split(" ")[1]
-        : req.body.token;
     const decodedToken = await admin.auth().verifyIdToken(token);
     const { email, name, uid } = decodedToken;
 

--- a/src/middlewares/socketAuth.js
+++ b/src/middlewares/socketAuth.js
@@ -2,8 +2,9 @@ const admin = require("firebase-admin");
 const User = require("../models/User");
 
 module.exports.socketAuth = async (socket, next) => {
+  const token = socket.handshake.query.token;
+
   try {
-    const token = socket.handshake.query.token;
     const decodedToken = await admin.auth().verifyIdToken(token);
     const { email } = decodedToken;
 

--- a/src/routes/adminUsers.js
+++ b/src/routes/adminUsers.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const router = express.Router();
+const { verifyToken } = require("../middlewares/auth");
+const { getPendingRequests } = require("../controllers/adminUser");
+
+router
+  .route("/server-addresses/:addressId/requests")
+  .get(verifyToken, getPendingRequests);
+
+module.exports = router;


### PR DESCRIPTION
## What is this PR?

This PR implements a new API that provides access request data for individual user server addresses.

<br>

## Changes / Description

This PR adds an API that allows users to manage access requests to their server addresses. By implementing this feature, administrators can effectively monitor and manage access requests to their servers.

<br>

## Details of Changes

- Implemented the GET '/server-addresses/:addressId/requests' route to handle access requests for user server addresses.
- Developed the getPendingRequests controller to process access requests for specific server addresses.
- Utilized UserServerRelation and ServerAddress models for database queries.
- Applied the .lean() method for optimized Mongoose queries.
- Included error handling for server-side issues.

<br>

## Reference Documents / Issues

.

<br>

## Screenshots (optional)

.

<br>

## Other Information (optional)

.

<br>
