### PR TITLE
fix: Refactor getPendingRequests to support multiple address IDs

### DIFF
--- a/src/routes/adminUsers.js
+++ b/src/routes/adminUsers.js
@@ -3,8 +3,6 @@ const router = express.Router();
 const { verifyToken } = require("../middlewares/auth");
 const { getPendingRequests } = require("../controllers/adminUser");
 
-router
-  .route("/server-addresses/:addressId/requests")
-  .get(verifyToken, getPendingRequests);
+router.route("/server-addresses/requests").get(verifyToken, getPendingRequests);
 
 module.exports = router;


### PR DESCRIPTION
## What is this PR?

This PR introduces major changes to the endpoint /server-addresses/:addressId/requests, transforming it into /server-addresses/requests, and modifies the getPendingRequests function to handle multiple address IDs.

<br>

## Changes / Description

Originally, the logic only handled a single address ID. This update is designed to efficiently process requests for multiple address IDs.

<br>

## Details of Changes

- Endpoint Change: Replaced the path parameter /:addressId with query parameters to accommodate multiple IDs.
- Modification of getPendingRequests function: Utilized Promise.all for parallel data fetching from UserServerRelation and ServerAddress models.
- Response Structure Update: The response now includes an array combining both requests and address information.

<br>

## Reference Documents / Issues

.

<br>

## Screenshots (optional)

.

<br>

## Other Information (optional)

.

<br>
