### PR TITLE
chore: Update variable names and remove isAdmin from getPendingReques…

### DIFF
--- a/src/controllers/adminUser.js
+++ b/src/controllers/adminUser.js
@@ -5,24 +5,22 @@ const getPendingRequests = async (req, res) => {
   const addressIds = req.query.id;
 
   try {
-    const requestsPromises = addressIds.map((addressId) =>
+    const requestPromises = addressIds.map((addressId) =>
       UserServerRelation.find({ addressId, isAdmin: false }).lean(),
     );
-
-    const addressesPromises = addressIds.map((addressId) =>
+    const addressPromises = addressIds.map((addressId) =>
       ServerAddress.findById(addressId).lean(),
     );
 
-    const requestsResults = await Promise.all(requestsPromises);
-    const addressesResults = await Promise.all(addressesPromises);
+    const requestResults = await Promise.all(requestPromises);
+    const addressResults = await Promise.all(addressPromises);
 
-    const combinedResults = requestsResults.map((requests, index) => ({
-      requests: requests,
-      address: addressesResults[index].address,
+    const combinedResults = requestResults.map((request, index) => ({
+      requests: request,
+      address: addressResults[index].address,
     }));
 
     res.status(200).json({
-      isAdmin: true,
       data: combinedResults,
     });
   } catch (error) {


### PR DESCRIPTION
## What is this PR?

This PR includes changes that remove the isAdmin value from the response object in the getPendingRequests controller function and refactor some variable names for consistency.

<br>

## Changes / Description

The motivation behind these changes is to enhance the simplicity of the API response and enable the frontend to determine the isAdmin value using resources already available. Additionally, the goal is to improve code readability through consistent variable naming.

<br>

## Details of Changes

- Refactored variable names within the getPendingRequests function to be consistent (e.g., changed requestsPromises to requestPromises).
- Removed the isAdmin field from the response object, allowing the frontend to determine admin status using available user information.

<br>

## Reference Documents / Issues

.

<br>

## Screenshots (optional)

.

<br>

## Other Information (optional)

.

<br>
