### PR TITLE
feat: Implement GET /api/v1/admin/users API Endpoint and getAccessReq…

### DIFF
--- a/src/controllers/adminUser.js
+++ b/src/controllers/adminUser.js
@@ -1,3 +1,4 @@
+const User = require("../models/User");
 const ServerAddress = require("../models/ServerAddress");
 const UserServerRelation = require("../models/UserServerRelation");
 
@@ -6,7 +7,7 @@ const getPendingRequests = async (req, res) => {
 
   try {
     const requestPromises = addressIds.map((addressId) =>
-      UserServerRelation.find({ addressId, isAdmin: false }).lean(),
+      UserServerRelation.find({ addressId, isApproved: false }).lean(),
     );
     const addressPromises = addressIds.map((addressId) =>
       ServerAddress.findById(addressId).lean(),
@@ -33,6 +34,63 @@ const getPendingRequests = async (req, res) => {
   }
 };
 
+const getAccessRequestUserList = async (req, res) => {
+  const uid = req.user.uid;
+  const serverAddress = req.query.address;
+  const userIds = Array.isArray(req.query.userId)
+    ? req.query.userId
+    : [req.query.userId];
+
+  if (!userIds.length) {
+    return res.status(200).json({ userList: [] });
+  }
+
+  try {
+    const userInfo = await User.findOne({ uid });
+
+    if (!userInfo) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    const serverInfo = await ServerAddress.findOne({ address: serverAddress });
+
+    if (!serverInfo) {
+      return res.status(404).json({ message: "Server address not found" });
+    }
+
+    const requestTarget = await UserServerRelation.findOne({
+      userId: userInfo._id,
+      addressId: serverInfo._id,
+    });
+
+    if (!requestTarget || !requestTarget.isAdmin) {
+      return res.status(403).json({ message: "Access denied" });
+    }
+
+    const requestUserPromises = userIds.map((userId) =>
+      User.findOne({ _id: userId }),
+    );
+
+    const requestUserResults = await Promise.all(requestUserPromises);
+
+    const requestUsersNameList = requestUserResults.map((user) => ({
+      name: user.name,
+    }));
+
+    res.status(200).json({
+      userList: requestUsersNameList,
+    });
+  } catch (error) {
+    console.error(error);
+
+    res.status(500).json({
+      status: "Error",
+      message: "Server encountered an error processing the request.",
+    });
+  }
+};
+
 module.exports = {
   getPendingRequests,
+  getAccessRequestUserList,
 };

--- a/src/routes/adminUsers.js
+++ b/src/routes/adminUsers.js
@@ -1,8 +1,13 @@
 const express = require("express");
 const router = express.Router();
 const { verifyToken } = require("../middlewares/auth");
-const { getPendingRequests } = require("../controllers/adminUser");
+const {
+  getPendingRequests,
+  getAccessRequestUserList,
+} = require("../controllers/adminUser");
 
 router.route("/server-addresses/requests").get(verifyToken, getPendingRequests);
+
+router.route("/users").get(verifyToken, getAccessRequestUserList);
 
 module.exports = router;


### PR DESCRIPTION
## What is this PR?

This PR implements the /api/v1/admin/users API endpoint and the getAccessRequestUserList controller.

<br>

## Changes / Description

This change extends the API functionality to allow admin users to manage access requests to the dashboard. This enables admins to view detailed information about dashboard access requests and to approve or deny them.
<br>

## Details of Changes

- Verifies an admin user's status based on their UID and the target server address for dashboard access requests.
- If the user is an admin, retrieves and sends a list of users who have requested access to the specified server address.
- Returns a 'Access denied' message with a 403 response if the user does not have admin privileges.
- Returns an empty array and avoids unnecessary database queries if the user ID list in the request is empty.
- While this change may add complexity to the API logic, it enables more flexible dashboard management.

<br>

## Reference Documents / Issues

.

<br>

## Screenshots (optional)

.

<br>

## Other Information (optional)

.

<br>
