### PR TITLE
chore: device name

### DIFF
--- a/src/services/prometheus.js
+++ b/src/services/prometheus.js
@@ -118,7 +118,7 @@ const getNetworkMetrics = async (address) => {
 };
 
 const getDiskMetrics = async (address) => {
-  const deviceName = address === "http://localhost:9090/" ? "disk0" : "xvda";
+  const deviceName = address === "http://localhost:9090/" ? "disk0" : "nvme0n1";
 
   const readRateQuery = `rate(node_disk_read_bytes_total{device="${deviceName}"}[30s])`;
   const writeRateQuery = `rate(node_disk_written_bytes_total{device="${deviceName}"}[30s])`;


### PR DESCRIPTION
## What is this PR?

I have recognized that the name of the Disk device defined in each environment is different, and have changed it to a device name suitable for the current situation.

<br>

## Changes / Description

I have inserted the appropriate value for the deviceName variable used in getDiskMetrics in services/prometheus.js.

<br>

## Details of Changes

Changed from const deviceName = address === "http://localhost:9090/" ? "disk0" : "xvda" to const deviceName = address === "http://localhost:9090/" ? "disk0" : "nvme0n1".

<br>

## Reference Documents / Issues

.

<br>

## Screenshots (optional)

.

<br>

## Other Information (optional)

Currently, the disk name is written as a temporary measure, but in the long term, it would be better to either allow the user to enter the device name or find a way to automatically determine it within the logic.

<br>
